### PR TITLE
Add GitHub Actions CD workflow for automatic deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm run build:frontend
+      - run: pnpm wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow (`.github/workflows/deploy.yml`) for continuous deployment
- Triggers automatically on push to `main` branch
- Builds frontend with Vite and deploys to Cloudflare Workers

## Setup Required
Add these secrets to the repository:
- `CLOUDFLARE_API_TOKEN` - API token with Workers permissions
- `CLOUDFLARE_ACCOUNT_ID` - Your Cloudflare account ID

## Test plan
- [ ] Add required secrets to GitHub repository
- [ ] Merge PR and verify workflow runs successfully
- [ ] Confirm deployment to Cloudflare Workers completes

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)