### PR TITLE
Display all bank detail fields including Danish account format

### DIFF
--- a/src/frontend/components/InvoiceDetail.tsx
+++ b/src/frontend/components/InvoiceDetail.tsx
@@ -104,40 +104,27 @@ export function InvoiceDetail({ invoiceId, onBack, onMarkPaid }: Props) {
           </dl>
         </div>
 
-        {(invoice.account_to_pay_IBAN ||
-          invoice.account_to_pay_BIC ||
-          invoice.account_to_pay_REG ||
-          invoice.account_to_pay_ACCOUNT_NUMBER) && (
-          <div className="detail-section">
-            <h2>Payment Information</h2>
-            <dl className="detail-grid">
-              {invoice.account_to_pay_IBAN && (
-                <div className="detail-item">
-                  <dt>IBAN</dt>
-                  <dd>{invoice.account_to_pay_IBAN}</dd>
-                </div>
-              )}
-              {invoice.account_to_pay_BIC && (
-                <div className="detail-item">
-                  <dt>BIC</dt>
-                  <dd>{invoice.account_to_pay_BIC}</dd>
-                </div>
-              )}
-              {invoice.account_to_pay_REG && (
-                <div className="detail-item">
-                  <dt>REG</dt>
-                  <dd>{invoice.account_to_pay_REG}</dd>
-                </div>
-              )}
-              {invoice.account_to_pay_ACCOUNT_NUMBER && (
-                <div className="detail-item">
-                  <dt>Account Number</dt>
-                  <dd>{invoice.account_to_pay_ACCOUNT_NUMBER}</dd>
-                </div>
-              )}
-            </dl>
-          </div>
-        )}
+        <div className="detail-section">
+          <h2>Payment Information</h2>
+          <dl className="detail-grid">
+            <div className="detail-item">
+              <dt>IBAN</dt>
+              <dd>{invoice.account_to_pay_IBAN || '-'}</dd>
+            </div>
+            <div className="detail-item">
+              <dt>BIC</dt>
+              <dd>{invoice.account_to_pay_BIC || '-'}</dd>
+            </div>
+            <div className="detail-item">
+              <dt>Registration Number</dt>
+              <dd>{invoice.account_to_pay_REG || '-'}</dd>
+            </div>
+            <div className="detail-item">
+              <dt>Account Number</dt>
+              <dd>{invoice.account_to_pay_ACCOUNT_NUMBER || '-'}</dd>
+            </div>
+          </dl>
+        </div>
 
         {items.length > 0 && (
           <div className="detail-section">


### PR DESCRIPTION
## Summary
- Always show Payment Information section with all 4 bank detail fields
- Display IBAN, BIC, Registration Number, and Account Number
- Show "-" placeholder when field values are not available
- Renamed "REG" label to "Registration Number" for clarity

## Test plan
- [ ] View an invoice with all bank fields populated - all should display
- [ ] View an invoice with missing bank fields - should show "-" for empty values
- [ ] Verify Payment Information section is always visible

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)