### PR TITLE
Add copy to clipboard for invoice details

### DIFF
--- a/src/frontend/components/CopyableField.tsx
+++ b/src/frontend/components/CopyableField.tsx
@@ -1,0 +1,53 @@
+import { useState, useCallback } from 'react';
+
+interface Props {
+  label: string;
+  value: string | null;
+  formatValue?: (value: string) => string;
+}
+
+export function CopyableField({ label, value, formatValue }: Props) {
+  const [copied, setCopied] = useState(false);
+  const displayValue = value ? (formatValue ? formatValue(value) : value) : '-';
+  const canCopy = value && typeof navigator !== 'undefined' && navigator.clipboard;
+
+  const handleCopy = useCallback(async () => {
+    if (!value || !navigator.clipboard) return;
+
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+  }, [value]);
+
+  return (
+    <div className="detail-item">
+      <dt>{label}</dt>
+      <dd className={canCopy ? 'copyable-value' : ''}>
+        <span>{displayValue}</span>
+        {canCopy && (
+          <button
+            className="copy-button"
+            onClick={handleCopy}
+            title={copied ? 'Copied!' : 'Click to copy'}
+            aria-label={`Copy ${label}`}
+          >
+            {copied ? (
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+            ) : (
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+              </svg>
+            )}
+          </button>
+        )}
+      </dd>
+    </div>
+  );
+}

--- a/src/frontend/components/InvoiceDetail.tsx
+++ b/src/frontend/components/InvoiceDetail.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { PDFViewer } from './PDFViewer';
 import { ImageViewer } from './ImageViewer';
+import { CopyableField } from './CopyableField';
 import type { InvoiceDetail as InvoiceDetailType } from '../types/invoice';
 
 interface Props {
@@ -74,22 +75,18 @@ export function InvoiceDetail({ invoiceId, onBack, onMarkPaid }: Props) {
         <div className="detail-section">
           <h2>Invoice Details</h2>
           <dl className="detail-grid">
-            <div className="detail-item">
-              <dt>Supplier</dt>
-              <dd>{invoice.supplier || '-'}</dd>
-            </div>
-            <div className="detail-item">
-              <dt>Invoice ID</dt>
-              <dd>{invoice.invoice_id || '-'}</dd>
-            </div>
-            <div className="detail-item">
-              <dt>Amount</dt>
-              <dd>{formatCurrency(invoice.amount)}</dd>
-            </div>
-            <div className="detail-item">
-              <dt>Due Date</dt>
-              <dd>{formatDate(invoice.last_payment_date)}</dd>
-            </div>
+            <CopyableField label="Supplier" value={invoice.supplier} />
+            <CopyableField label="Invoice ID" value={invoice.invoice_id} />
+            <CopyableField
+              label="Amount"
+              value={invoice.amount?.toString() ?? null}
+              formatValue={(v) => formatCurrency(parseFloat(v))}
+            />
+            <CopyableField
+              label="Due Date"
+              value={invoice.last_payment_date}
+              formatValue={formatDate}
+            />
             <div className="detail-item">
               <dt>Status</dt>
               <dd>
@@ -108,22 +105,10 @@ export function InvoiceDetail({ invoiceId, onBack, onMarkPaid }: Props) {
         <div className="detail-section">
           <h2>Payment Information</h2>
           <dl className="detail-grid">
-            <div className="detail-item">
-              <dt>IBAN</dt>
-              <dd>{invoice.account_to_pay_IBAN || '-'}</dd>
-            </div>
-            <div className="detail-item">
-              <dt>BIC</dt>
-              <dd>{invoice.account_to_pay_BIC || '-'}</dd>
-            </div>
-            <div className="detail-item">
-              <dt>Registration Number</dt>
-              <dd>{invoice.account_to_pay_REG || '-'}</dd>
-            </div>
-            <div className="detail-item">
-              <dt>Account Number</dt>
-              <dd>{invoice.account_to_pay_ACCOUNT_NUMBER || '-'}</dd>
-            </div>
+            <CopyableField label="IBAN" value={invoice.account_to_pay_IBAN} />
+            <CopyableField label="BIC" value={invoice.account_to_pay_BIC} />
+            <CopyableField label="REG" value={invoice.account_to_pay_REG} />
+            <CopyableField label="Account Number" value={invoice.account_to_pay_ACCOUNT_NUMBER} />
           </dl>
         </div>
 

--- a/src/frontend/styles/globals.css
+++ b/src/frontend/styles/globals.css
@@ -622,3 +622,41 @@ body {
 .image-viewport img.actual-mode {
   transform-origin: center center;
 }
+
+/* Copyable Field */
+.copyable-value {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.copy-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.15rem;
+  background: transparent;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  color: #888;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s, background 0.15s;
+}
+
+.copyable-value:hover .copy-button {
+  opacity: 1;
+}
+
+.copy-button:hover {
+  background: #e5e5e5;
+  color: #333;
+}
+
+.copy-button:active {
+  background: #d5d5d5;
+}
+
+.copy-button svg {
+  display: block;
+}


### PR DESCRIPTION
## Summary
- Add reusable CopyableField component with copy-to-clipboard functionality
- Add copy buttons to invoice detail fields (Supplier, Invoice ID, Amount, Due Date, IBAN, BIC, REG, Account Number)
- Show subtle copy icon on hover that changes to checkmark after copying

## Test plan
- [ ] Navigate to an invoice detail view
- [ ] Hover over a copiable field (e.g., IBAN) and verify copy icon appears
- [ ] Click copy icon and verify value is copied to clipboard
- [ ] Verify checkmark icon appears briefly after copying
- [ ] Test on fields with empty values (should show "-" with no copy button)

Closes #8