### PR TITLE
Add explicit currency display and account balance support

### DIFF
--- a/create.sql
+++ b/create.sql
@@ -3,6 +3,8 @@ CREATE TABLE IF NOT EXISTS invoices (
       message_id TEXT NOT NULL UNIQUE,
       supplier TEXT,
       amount REAL,
+      currency TEXT,
+      account_balance REAL,
       invoice_id TEXT,
       account_to_pay_IBAN TEXT,
       account_to_pay_BIC TEXT,
@@ -10,7 +12,7 @@ CREATE TABLE IF NOT EXISTS invoices (
       account_to_pay_ACCOUNT_NUMBER TEXT,
       last_payment_date TEXT,
       items_json TEXT,
-      paid INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'unpaid',
       paid_at TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     );

--- a/migrations/0002_add_account_balance_column.sql
+++ b/migrations/0002_add_account_balance_column.sql
@@ -1,0 +1,4 @@
+-- Migration: Add account_balance column to invoices table
+-- This allows storing positive credit balances (tilgodehavende) separately from amounts to pay
+
+ALTER TABLE invoices ADD COLUMN account_balance REAL;

--- a/migrations/0003_add_status_column.sql
+++ b/migrations/0003_add_status_column.sql
@@ -1,0 +1,12 @@
+-- Migration: Replace paid boolean with status enum
+-- Status values: 'unpaid', 'paid', 'no_payment_due'
+
+-- Add status column
+ALTER TABLE invoices ADD COLUMN status TEXT NOT NULL DEFAULT 'unpaid';
+
+-- Migrate existing data
+UPDATE invoices SET status = 'paid' WHERE paid = 1;
+UPDATE invoices SET status = 'no_payment_due' WHERE paid = 0 AND account_balance IS NOT NULL AND (amount IS NULL OR amount = 0);
+
+-- Note: We keep paid and paid_at columns for now to avoid data loss
+-- They can be removed in a future migration after verifying the status column works correctly

--- a/src/frontend/components/InvoiceDetail.tsx
+++ b/src/frontend/components/InvoiceDetail.tsx
@@ -93,6 +93,16 @@ export function InvoiceDetail({ invoiceId, onBack, onMarkPaid, onDelete }: Props
               value={invoice.amount?.toString() ?? null}
               formatValue={(v) => formatCurrency(parseFloat(v), invoice.currency)}
             />
+            {invoice.account_balance && (
+              <div className="detail-item">
+                <dt>Credit Balance</dt>
+                <dd>
+                  <span className="status-badge balance">
+                    {formatCurrency(invoice.account_balance, invoice.currency)}
+                  </span>
+                </dd>
+              </div>
+            )}
             <CopyableField
               label="Due Date"
               value={invoice.last_payment_date}
@@ -101,8 +111,8 @@ export function InvoiceDetail({ invoiceId, onBack, onMarkPaid, onDelete }: Props
             <div className="detail-item">
               <dt>Status</dt>
               <dd>
-                <span className={`status-badge ${invoice.paid ? 'paid' : 'unpaid'}`}>
-                  {invoice.paid ? `Paid on ${formatDate(invoice.paid_at)}` : 'Unpaid'}
+                <span className={`status-badge ${invoice.status === 'paid' ? 'paid' : (invoice.status === 'no_payment_due' ? 'balance' : 'unpaid')}`}>
+                  {invoice.status === 'paid' ? `Paid on ${formatDate(invoice.paid_at)}` : (invoice.status === 'no_payment_due' ? 'All good' : 'Unpaid')}
                 </span>
               </dd>
             </div>
@@ -135,7 +145,7 @@ export function InvoiceDetail({ invoiceId, onBack, onMarkPaid, onDelete }: Props
         )}
 
         <div className="detail-section action-buttons">
-          {!invoice.paid && (
+          {invoice.status === 'unpaid' && (
             <button
               className="mark-paid-button"
               onClick={handleMarkPaid}

--- a/src/frontend/styles/globals.css
+++ b/src/frontend/styles/globals.css
@@ -161,6 +161,11 @@ body {
   color: #92400e;
 }
 
+.status-badge.balance {
+  background: #dcfce7;
+  color: #166534;
+}
+
 /* Invoice Detail - Side by Side Layout */
 .invoice-detail-layout {
   display: grid;

--- a/src/frontend/types/invoice.ts
+++ b/src/frontend/types/invoice.ts
@@ -1,12 +1,15 @@
+export type InvoiceStatus = 'unpaid' | 'paid' | 'no_payment_due';
+
 export interface InvoiceListItem {
   id: number;
   message_id: string;
   supplier: string | null;
   amount: number | null;
   currency: string | null;
+  account_balance: number | null;
   invoice_id: string | null;
   last_payment_date: string | null;
-  paid: number;
+  status: InvoiceStatus;
   paid_at: string | null;
   created_at: string;
 }

--- a/src/utils/ai-processing.ts
+++ b/src/utils/ai-processing.ts
@@ -11,6 +11,7 @@ export interface InvoiceExtraction {
   supplier: string | null;
   amount: number | null;
   currency: string | null;
+  accountBalance: number | null;
   invoiceId: string | null;
   accountIBAN: string | null;
   accountBIC: string | null;
@@ -142,8 +143,9 @@ export async function extractInvoiceInfo(
 Required fields (all can be null if not found):
 - items: array of strings describing what items/services are covered (can be empty array)
 - supplier: the name of the supplier/company that sent the invoice
-- amount: the total amount to pay (as a number)
+- amount: the total amount to pay (as a number, null if nothing to pay or there is a positive balance)
 - currency: the currency code (e.g. "DKK", "SEK", "EUR", "USD")
+- accountBalance: positive remaining credit balance in your favor (as a number, null if no balance - this is for cases where the customer has prepaid or overpaid)
 - invoiceId: the invoice number or ID
 - accountIBAN: the IBAN (International Bank Account Number) if available
 - accountBIC: the BIC/SWIFT code for international accounts if available
@@ -161,6 +163,7 @@ Return ONLY valid JSON in this exact format:
   "supplier": "Supplier Name" or null,
   "amount": 1234.56 or null,
   "currency": "DKK" or null,
+  "accountBalance": 250.00 or null,
   "invoiceId": "INV-123" or null,
   "accountIBAN": "DK1234567890123456" or null,
   "accountBIC": "DABADKKK" or null,
@@ -195,6 +198,7 @@ Return ONLY valid JSON in this exact format:
         supplier: extracted.supplier || null,
         amount: extracted.amount || null,
         currency: extracted.currency || null,
+        accountBalance: extracted.accountBalance || null,
         invoiceId: extracted.invoiceId || null,
         accountIBAN: extracted.accountIBAN || null,
         accountBIC: extracted.accountBIC || null,
@@ -214,6 +218,7 @@ Return ONLY valid JSON in this exact format:
       supplier: null,
       amount: null,
       currency: null,
+      accountBalance: null,
       invoiceId: null,
       accountIBAN: null,
       accountBIC: null,

--- a/src/utils/email-replies.ts
+++ b/src/utils/email-replies.ts
@@ -66,6 +66,14 @@ function generateSummaryText(extraction: InvoiceExtraction): string {
       }).format(extraction.amount)
     : 'Ikke angivet';
 
+  const accountBalanceFormatted = extraction.accountBalance
+    ? new Intl.NumberFormat('da-DK', {
+        style: 'currency',
+        currency: extraction.currency || 'DKK',
+        currencyDisplay: 'code',
+      }).format(extraction.accountBalance)
+    : null;
+
   const paymentDateText = extraction.lastPaymentDate
     ? `Last Payment Date: ${extraction.lastPaymentDate}`
     : 'Last Payment Date: Not specified';
@@ -87,7 +95,7 @@ Jeg har behandlet din faktura og ekstraheret følgende information:
 📋 Faktura Detaljer:
 - Faktura ID: ${extraction.invoiceId || 'Ikke angivet'}
 - Leverandør: ${extraction.supplier || 'Ikke angivet'}
-- Beløb: ${amountFormatted}
+- Beløb: ${amountFormatted}${accountBalanceFormatted ? `\n- Tilgodehavende: ${accountBalanceFormatted}` : ''}
 - Konto - IBAN: ${extraction.accountIBAN || 'Ikke angivet'}
 - Konto - BIC: ${extraction.accountBIC || 'Ikke angivet'}
 - Konto - Reg. nummer: ${extraction.accountREG || 'Ikke angivet'}


### PR DESCRIPTION
## Summary
- Display currency code explicitly (DKK, SEK, EUR, etc.) instead of generic "kr"
- Add `account_balance` field for invoices with credit/positive balance
- Replace `paid` boolean with `status` enum: `unpaid`, `paid`, `no_payment_due`
- Show "All good" status (green badge) for invoices with credit balance and nothing to pay
- Update filter to properly exclude "All good" invoices from "Unpaid" filter
- Hide "Mark as Paid" button for invoices that don't require payment

## Test plan
- [ ] Run migrations locally: `pnpm exec wrangler d1 migrations apply bjrk-d1 --local`
- [ ] Start dev server: `pnpm dev`
- [ ] Verify currency codes display correctly in invoice list and detail views
- [ ] Insert test invoice with account balance and verify "All good" status displays
- [ ] Verify "Unpaid" filter excludes "All good" invoices
- [ ] Verify "Mark as Paid" button only appears for unpaid invoices

Closes #25