### PR TITLE
Allow users to update all invoice fields

### DIFF
--- a/migrations/0004_add_manually_edited_fields.sql
+++ b/migrations/0004_add_manually_edited_fields.sql
@@ -1,0 +1,3 @@
+-- Add column to track which fields have been manually edited by the user
+-- Stores a JSON array of field names, e.g. ["amount", "supplier"]
+ALTER TABLE invoices ADD COLUMN manually_edited_fields TEXT;

--- a/src/api/invoices.ts
+++ b/src/api/invoices.ts
@@ -18,6 +18,7 @@ export interface InvoiceListItem {
   status: InvoiceStatus;
   paid_at: string | null;
   created_at: string;
+  manually_edited_fields: string[] | null;
 }
 
 export interface InvoiceDetail extends InvoiceListItem {
@@ -26,7 +27,46 @@ export interface InvoiceDetail extends InvoiceListItem {
   account_to_pay_REG: string | null;
   account_to_pay_ACCOUNT_NUMBER: string | null;
   items_json: string | null;
+  manually_edited_fields: string[] | null;
   source_files: SourceFileRecord[];
+}
+
+// Fields that can be updated by the user
+export type EditableField =
+  | 'supplier'
+  | 'amount'
+  | 'currency'
+  | 'account_balance'
+  | 'invoice_id'
+  | 'account_to_pay_IBAN'
+  | 'account_to_pay_BIC'
+  | 'account_to_pay_REG'
+  | 'account_to_pay_ACCOUNT_NUMBER'
+  | 'last_payment_date'
+  | 'status';
+
+export interface InvoiceUpdateRequest {
+  supplier?: string | null;
+  amount?: number | null;
+  currency?: string | null;
+  account_balance?: number | null;
+  invoice_id?: string | null;
+  account_to_pay_IBAN?: string | null;
+  account_to_pay_BIC?: string | null;
+  account_to_pay_REG?: string | null;
+  account_to_pay_ACCOUNT_NUMBER?: string | null;
+  last_payment_date?: string | null;
+  status?: InvoiceStatus;
+}
+
+// Helper to parse manually_edited_fields JSON string to array
+function parseManuallyEditedFields(json: string | null): string[] | null {
+  if (!json) return null;
+  try {
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
 }
 
 export async function getAllInvoices(
@@ -34,7 +74,7 @@ export async function getAllInvoices(
   options?: { limit?: number; offset?: number; unpaidOnly?: boolean }
 ): Promise<InvoiceListItem[]> {
   let query = `SELECT id, message_id, supplier, amount, currency, account_balance, invoice_id,
-               last_payment_date, status, paid_at, created_at
+               last_payment_date, status, paid_at, created_at, manually_edited_fields
                FROM invoices`;
 
   if (options?.unpaidOnly) {
@@ -50,8 +90,12 @@ export async function getAllInvoices(
     }
   }
 
-  const result = await db.prepare(query).all<InvoiceListItem>();
-  return result.results;
+  const result = await db.prepare(query).all<InvoiceRecord>();
+  return result.results.map((invoice) => ({
+    ...invoice,
+    id: invoice.id!,
+    manually_edited_fields: parseManuallyEditedFields(invoice.manually_edited_fields),
+  }));
 }
 
 export async function getInvoiceById(
@@ -75,6 +119,7 @@ export async function getInvoiceById(
   return {
     ...invoice,
     id: invoice.id!,
+    manually_edited_fields: parseManuallyEditedFields(invoice.manually_edited_fields),
     source_files: sourceFilesResult.results,
   };
 }
@@ -118,4 +163,99 @@ export async function deleteInvoice(
     .run();
 
   return result.success;
+}
+
+export async function updateInvoice(
+  db: D1Database,
+  id: number,
+  updates: InvoiceUpdateRequest
+): Promise<InvoiceDetail | null> {
+  // First get the current invoice to merge manually_edited_fields
+  const currentInvoice = await db
+    .prepare(`SELECT manually_edited_fields, status FROM invoices WHERE id = ?`)
+    .bind(id)
+    .first<{ manually_edited_fields: string | null; status: InvoiceStatus }>();
+
+  if (!currentInvoice) {
+    return null;
+  }
+
+  // Parse existing manually edited fields
+  const existingEditedFields = parseManuallyEditedFields(currentInvoice.manually_edited_fields) || [];
+
+  // Determine which fields are being updated
+  const fieldsBeingUpdated = Object.keys(updates) as EditableField[];
+
+  // Merge with existing edited fields (no duplicates)
+  const newEditedFields = [...new Set([...existingEditedFields, ...fieldsBeingUpdated])];
+
+  // Build dynamic UPDATE query
+  const setClauses: string[] = [];
+  const values: unknown[] = [];
+
+  // Add each field that's being updated
+  if (updates.supplier !== undefined) {
+    setClauses.push('supplier = ?');
+    values.push(updates.supplier);
+  }
+  if (updates.amount !== undefined) {
+    setClauses.push('amount = ?');
+    values.push(updates.amount);
+  }
+  if (updates.currency !== undefined) {
+    setClauses.push('currency = ?');
+    values.push(updates.currency);
+  }
+  if (updates.account_balance !== undefined) {
+    setClauses.push('account_balance = ?');
+    values.push(updates.account_balance);
+  }
+  if (updates.invoice_id !== undefined) {
+    setClauses.push('invoice_id = ?');
+    values.push(updates.invoice_id);
+  }
+  if (updates.account_to_pay_IBAN !== undefined) {
+    setClauses.push('account_to_pay_IBAN = ?');
+    values.push(updates.account_to_pay_IBAN);
+  }
+  if (updates.account_to_pay_BIC !== undefined) {
+    setClauses.push('account_to_pay_BIC = ?');
+    values.push(updates.account_to_pay_BIC);
+  }
+  if (updates.account_to_pay_REG !== undefined) {
+    setClauses.push('account_to_pay_REG = ?');
+    values.push(updates.account_to_pay_REG);
+  }
+  if (updates.account_to_pay_ACCOUNT_NUMBER !== undefined) {
+    setClauses.push('account_to_pay_ACCOUNT_NUMBER = ?');
+    values.push(updates.account_to_pay_ACCOUNT_NUMBER);
+  }
+  if (updates.last_payment_date !== undefined) {
+    setClauses.push('last_payment_date = ?');
+    values.push(updates.last_payment_date);
+  }
+  if (updates.status !== undefined) {
+    setClauses.push('status = ?');
+    values.push(updates.status);
+    // If changing to 'paid', set paid_at; if changing from 'paid', clear paid_at
+    if (updates.status === 'paid') {
+      setClauses.push("paid_at = datetime('now')");
+    } else if (currentInvoice.status === 'paid') {
+      // We're in else branch so updates.status is not 'paid', clear paid_at
+      setClauses.push('paid_at = NULL');
+    }
+  }
+
+  // Always update manually_edited_fields
+  setClauses.push('manually_edited_fields = ?');
+  values.push(JSON.stringify(newEditedFields));
+
+  // Add id for WHERE clause
+  values.push(id);
+
+  const query = `UPDATE invoices SET ${setClauses.join(', ')} WHERE id = ?`;
+  await db.prepare(query).bind(...values).run();
+
+  // Return the updated invoice
+  return getInvoiceById(db, id);
 }

--- a/src/frontend/components/EditableField.tsx
+++ b/src/frontend/components/EditableField.tsx
@@ -1,0 +1,173 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+
+interface Props {
+  label: string;
+  fieldName: string;
+  value: string | null;
+  formatValue?: (value: string) => string;
+  parseValue?: (displayValue: string) => string | null;
+  isEdited?: boolean;
+  onSave: (fieldName: string, value: string | null) => Promise<void>;
+  inputType?: 'text' | 'number' | 'date';
+}
+
+export function EditableField({
+  label,
+  fieldName,
+  value,
+  formatValue,
+  parseValue,
+  isEdited = false,
+  onSave,
+  inputType = 'text',
+}: Props) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const displayValue = value ? (formatValue ? formatValue(value) : value) : '-';
+  const canCopy = value && typeof navigator !== 'undefined' && navigator.clipboard;
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  const handleCopy = useCallback(async () => {
+    if (!value || !navigator.clipboard) return;
+
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+  }, [value]);
+
+  const startEditing = () => {
+    setEditValue(value || '');
+    setIsEditing(true);
+  };
+
+  const cancelEditing = () => {
+    setIsEditing(false);
+    setEditValue('');
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const newValue = editValue.trim() || null;
+      const parsedValue = parseValue ? parseValue(editValue.trim()) : newValue;
+      await onSave(fieldName, parsedValue);
+      setIsEditing(false);
+    } catch (err) {
+      console.error('Failed to save:', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleSave();
+    } else if (e.key === 'Escape') {
+      cancelEditing();
+    }
+  };
+
+  if (isEditing) {
+    return (
+      <div className="detail-item">
+        <dt>{label}</dt>
+        <dd className="editable-field editing">
+          <input
+            ref={inputRef}
+            type={inputType}
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            disabled={saving}
+            className="edit-input"
+          />
+          <div className="edit-actions">
+            <button
+              className="edit-action-button save"
+              onClick={handleSave}
+              disabled={saving}
+              title="Save"
+            >
+              {saving ? '...' : (
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+              )}
+            </button>
+            <button
+              className="edit-action-button cancel"
+              onClick={cancelEditing}
+              disabled={saving}
+              title="Cancel"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+        </dd>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`detail-item ${isEdited ? 'manually-edited' : ''}`}>
+      <dt>
+        {label}
+        {isEdited && (
+          <span className="edited-indicator" title="Manually edited">*</span>
+        )}
+      </dt>
+      <dd className="editable-field">
+        <span className={canCopy ? 'copyable-value' : ''}>
+          <span>{displayValue}</span>
+          {canCopy && (
+            <button
+              className="copy-button"
+              onClick={handleCopy}
+              title={copied ? 'Copied!' : 'Click to copy'}
+              aria-label={`Copy ${label}`}
+            >
+              {copied ? (
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+              ) : (
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                </svg>
+              )}
+            </button>
+          )}
+        </span>
+        <button
+          className="edit-button"
+          onClick={startEditing}
+          title="Edit"
+          aria-label={`Edit ${label}`}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+          </svg>
+        </button>
+      </dd>
+    </div>
+  );
+}

--- a/src/frontend/components/StatusSelect.tsx
+++ b/src/frontend/components/StatusSelect.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import type { InvoiceStatus } from '../types/invoice';
+
+interface Props {
+  status: InvoiceStatus;
+  paidAt: string | null;
+  isEdited?: boolean;
+  onSave: (status: InvoiceStatus) => Promise<void>;
+  formatDate: (date: string | null) => string;
+}
+
+const STATUS_OPTIONS: { value: InvoiceStatus; label: string }[] = [
+  { value: 'unpaid', label: 'Unpaid' },
+  { value: 'paid', label: 'Paid' },
+  { value: 'no_payment_due', label: 'All good (no payment due)' },
+];
+
+export function StatusSelect({ status, paidAt, isEdited = false, onSave, formatDate }: Props) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const handleChange = async (newStatus: InvoiceStatus) => {
+    if (newStatus === status) {
+      setIsEditing(false);
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await onSave(newStatus);
+      setIsEditing(false);
+    } catch (err) {
+      console.error('Failed to save status:', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const getStatusDisplay = () => {
+    if (status === 'paid') {
+      return `Paid on ${formatDate(paidAt)}`;
+    } else if (status === 'no_payment_due') {
+      return 'All good';
+    }
+    return 'Unpaid';
+  };
+
+  const getStatusClass = () => {
+    if (status === 'paid') return 'paid';
+    if (status === 'no_payment_due') return 'balance';
+    return 'unpaid';
+  };
+
+  if (isEditing) {
+    return (
+      <div className={`detail-item ${isEdited ? 'manually-edited' : ''}`}>
+        <dt>
+          Status
+          {isEdited && <span className="edited-indicator" title="Manually edited">*</span>}
+        </dt>
+        <dd className="status-editing">
+          <select
+            value={status}
+            onChange={(e) => handleChange(e.target.value as InvoiceStatus)}
+            disabled={saving}
+            className="status-select"
+            autoFocus
+          >
+            {STATUS_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          <button
+            className="edit-action-button cancel"
+            onClick={() => setIsEditing(false)}
+            disabled={saving}
+            title="Cancel"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </dd>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`detail-item ${isEdited ? 'manually-edited' : ''}`}>
+      <dt>
+        Status
+        {isEdited && <span className="edited-indicator" title="Manually edited">*</span>}
+      </dt>
+      <dd className="editable-field">
+        <span className={`status-badge ${getStatusClass()}`}>
+          {getStatusDisplay()}
+        </span>
+        <button
+          className="edit-button"
+          onClick={() => setIsEditing(true)}
+          title="Edit status"
+          aria-label="Edit status"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+          </svg>
+        </button>
+      </dd>
+    </div>
+  );
+}

--- a/src/frontend/styles/globals.css
+++ b/src/frontend/styles/globals.css
@@ -877,3 +877,126 @@ body {
   gap: 0.75rem;
   flex-wrap: wrap;
 }
+
+/* Editable Field */
+.editable-field {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.editable-field.editing {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.35rem;
+}
+
+.edit-input {
+  width: 100%;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid #2563eb;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  outline: none;
+}
+
+.edit-input:focus {
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
+}
+
+.edit-actions {
+  display: flex;
+  gap: 0.25rem;
+  justify-content: flex-end;
+}
+
+.edit-action-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  background: transparent;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  cursor: pointer;
+  color: #666;
+  transition: all 0.15s;
+}
+
+.edit-action-button.save {
+  color: #059669;
+  border-color: #059669;
+}
+
+.edit-action-button.save:hover {
+  background: #059669;
+  color: white;
+}
+
+.edit-action-button.cancel {
+  color: #666;
+}
+
+.edit-action-button.cancel:hover {
+  background: #e5e5e5;
+}
+
+.edit-action-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.edit-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.15rem;
+  background: transparent;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  color: #888;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s, background 0.15s;
+}
+
+.editable-field:hover .edit-button {
+  opacity: 1;
+}
+
+.edit-button:hover {
+  background: #e5e5e5;
+  color: #2563eb;
+}
+
+/* Manually edited indicator */
+.manually-edited dt {
+  color: #2563eb;
+}
+
+.edited-indicator {
+  color: #2563eb;
+  font-weight: bold;
+  margin-left: 0.25rem;
+}
+
+/* Status editing */
+.status-editing {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.status-select {
+  padding: 0.35rem 0.5rem;
+  border: 1px solid #2563eb;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  background: white;
+  cursor: pointer;
+  outline: none;
+}
+
+.status-select:focus {
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
+}

--- a/src/frontend/types/invoice.ts
+++ b/src/frontend/types/invoice.ts
@@ -12,6 +12,7 @@ export interface InvoiceListItem {
   status: InvoiceStatus;
   paid_at: string | null;
   created_at: string;
+  manually_edited_fields: string[] | null;
 }
 
 export interface SourceFile {

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -50,6 +50,7 @@ export interface InvoiceRecord {
   status: 'unpaid' | 'paid' | 'no_payment_due';
   paid_at: string | null;
   created_at: string;
+  manually_edited_fields: string | null; // JSON array of field names that were manually edited
 }
 
 export interface SourceFileRecord {


### PR DESCRIPTION
## Summary
- Users can now edit all extracted value fields (supplier, amount, currency, invoice_id, due date, payment account details)
- Users can change the status field (unpaid/paid/no_payment_due) to correct misclassifications
- Manually edited fields are visually marked with an asterisk (*) and blue highlight

## Implementation
- Added `manually_edited_fields` column to track which fields were edited by users
- Updated PATCH endpoint to accept partial updates for all editable fields  
- Created `EditableField` component with inline editing, copy-to-clipboard, and save/cancel
- Created `StatusSelect` dropdown component for status changes
- Status changes properly manage `paid_at` timestamp (set on paid, clear on unpaid)

## Test plan
- [ ] Verify editing text fields (supplier, invoice_id) works and persists
- [ ] Verify editing numeric fields (amount, credit balance) handles number parsing
- [ ] Verify editing date field (due date) works with date picker
- [ ] Verify status dropdown changes work and paid_at is updated correctly
- [ ] Verify edited fields show asterisk indicator
- [ ] Verify existing "Mark as Paid" button still works (backwards compat)
- [ ] Run migration on existing database

Closes #28