### PR TITLE
Route image attachments to Claude via AI Gateway

### DIFF
--- a/manual_test/test_email.py
+++ b/manual_test/test_email.py
@@ -11,6 +11,7 @@ import email.utils
 import mimetypes
 import os
 from email.mime.application import MIMEApplication
+from email.mime.image import MIMEImage
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from typing import List, Optional
@@ -92,9 +93,15 @@ def create_and_send_email(
                 else:
                     content_type = 'application/octet-stream'
             
-            # Read file and attach
+            # Read file and attach using the correct MIME class so the
+            # top-level type matches (image/* vs application/*).
             with open(file_path, 'rb') as f:
-                part = MIMEApplication(f.read(), _subtype=content_type.split('/')[1])
+                file_bytes = f.read()
+            major, _, minor = content_type.partition('/')
+            if major == 'image':
+                part = MIMEImage(file_bytes, _subtype=minor)
+            else:
+                part = MIMEApplication(file_bytes, _subtype=minor)
             
             part.add_header(
                 'Content-Disposition',
@@ -151,8 +158,7 @@ if __name__ == '__main__':
         to_email="recipient@example.com",
         subject="Invoice attached",
         body="Please find the invoice and photo attached.",
-        # attachments=["./test_data/test_invoice_1.pdf", "./test_data/test_invoice_1.jpg"]
-        attachments=["./test_data/test_invoice_1.pdf"]
+        attachments=["./test_data/test_invoice_1.jpg"]
     )
     print(f"Status: {response.status_code}")
     print(f"Response: {response.text}")

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import {
 import {
   processEmailAndAttachmentsToMarkdown,
   extractInvoiceInfo,
+  getVisionGatewayConfig,
 } from './utils/ai-processing';
 import {
   initializeDatabase,
@@ -112,7 +113,8 @@ export default {
         env.AI,
         email.text,
         email.html,
-        attachmentData
+        attachmentData,
+        getVisionGatewayConfig(env)
       );
 
       // Persist each markdown file individually to silver layer
@@ -287,7 +289,8 @@ async function handleApiRequest(
         env.AI,
         undefined,
         undefined,
-        attachments
+        attachments,
+        getVisionGatewayConfig(env)
       );
 
       // Extract invoice info

--- a/src/utils/ai-processing.ts
+++ b/src/utils/ai-processing.ts
@@ -43,10 +43,167 @@ export interface ConversionResult {
   error?: string;
 }
 
+export interface VisionGatewayConfig {
+  accountId: string;
+  gatewayId: string;
+  anthropicApiKey: string;
+  gatewayToken?: string;
+  model?: string;
+}
+
+export function getVisionGatewayConfig(env: any): VisionGatewayConfig | undefined {
+  const accountId = env?.CLOUDFLARE_ACCOUNT_ID;
+  const gatewayId = env?.AI_GATEWAY_ID;
+  const anthropicApiKey = env?.ANTHROPIC_API_KEY;
+  const gatewayToken = env?.AI_GATEWAY_TOKEN || undefined;
+  const missing: string[] = [];
+  if (!accountId) missing.push('CLOUDFLARE_ACCOUNT_ID');
+  if (!gatewayId) missing.push('AI_GATEWAY_ID');
+  if (!anthropicApiKey) missing.push('ANTHROPIC_API_KEY');
+  if (missing.length > 0) {
+    console.warn(
+      `Claude vision extraction disabled — missing env: ${missing.join(', ')}. ` +
+        `Image attachments will fall back to Cloudflare toMarkdown, which extracts images poorly.`
+    );
+    return undefined;
+  }
+  return { accountId, gatewayId, anthropicApiKey, gatewayToken };
+}
+
+const CLAUDE_SUPPORTED_IMAGE_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+]);
+
+function isImageAttachment(contentType: string): boolean {
+  return CLAUDE_SUPPORTED_IMAGE_TYPES.has(contentType.toLowerCase().split(';')[0].trim());
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode.apply(
+      null,
+      Array.from(bytes.subarray(i, i + chunkSize))
+    );
+  }
+  return btoa(binary);
+}
+
+const VISION_PROMPT = `You are transcribing an invoice image into a structured key/value markdown document that a downstream parser will read. Do NOT invent values — use "null" for anything not clearly visible.
+
+Return ONLY markdown in this exact shape:
+
+\`\`\`
+# <short title of the document>
+
+- document_type: <one of: invoice | receipt | credit_note | payment_request | newsletter | marketing | notification | other>
+- supplier: <company name or null>
+- invoice_id: <invoice/reference number or null>
+- amount: <total amount to pay as a plain number, or null if nothing is due>
+- currency: <ISO code like DKK, SEK, EUR, USD, or null>
+- account_balance: <positive credit balance in customer's favor as a plain number, or null — use this for credit notes and "belopp tillgodo"/"tilgodehavende" style amounts instead of amount>
+- last_payment_date: <due date in YYYY-MM-DD, or null. Look for "Förfallodatum", "Betalningsdatum", "Sista betalningsdag", "Oss til handa", "Oss tillhanda", "Due date", "Forfaldsdato", "Betalingsdato">
+- account_iban: <full IBAN with no spaces, or null>
+- account_bic: <BIC/SWIFT, or null>
+- account_reg: <Danish REG number, null unless currency is DKK>
+- account_number: <Danish account number, null unless currency is DKK>
+
+## items
+- <line item 1>
+- <line item 2>
+\`\`\`
+
+Rules:
+- Never return a negative amount. If the document shows a credit/negative total, put the absolute value in account_balance and leave amount as null.
+- Only populate account_reg and account_number when the currency is DKK.
+- Keep items short — one bullet per line item, empty list allowed.
+- Output the markdown only, no surrounding prose, no code fences.`;
+
+async function extractImageToMarkdown(
+  config: VisionGatewayConfig,
+  attachment: { filename: string; contentType: string; data: ArrayBuffer }
+): Promise<{ filename: string; content: string }> {
+  const model = config.model || 'claude-haiku-4-5-20251001';
+  const url = `https://gateway.ai.cloudflare.com/v1/${config.accountId}/${config.gatewayId}/anthropic/v1/messages`;
+  const mediaType = attachment.contentType.toLowerCase().split(';')[0].trim();
+
+  const body = {
+    model,
+    max_tokens: 2048,
+    temperature: 0,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: mediaType,
+              data: arrayBufferToBase64(attachment.data),
+            },
+          },
+          { type: 'text', text: VISION_PROMPT },
+        ],
+      },
+    ],
+  };
+
+  try {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'x-api-key': config.anthropicApiKey,
+      'anthropic-version': '2023-06-01',
+    };
+    if (config.gatewayToken) {
+      headers['cf-aig-authorization'] = `Bearer ${config.gatewayToken}`;
+    }
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Claude vision call failed ${response.status}: ${errorText}`);
+    }
+
+    const result = (await response.json()) as {
+      content?: Array<{ type: string; text?: string }>;
+    };
+
+    const text = (result.content || [])
+      .filter((block) => block.type === 'text')
+      .map((block) => block.text || '')
+      .join('\n')
+      .trim();
+
+    if (!text) {
+      throw new Error('Empty response from Claude vision');
+    }
+
+    return { filename: attachment.filename, content: text };
+  } catch (error) {
+    console.error(`Error extracting image ${attachment.filename} via Claude:`, error);
+    return {
+      filename: attachment.filename,
+      content: `# ${attachment.filename}\n\n[Image extraction failed: ${error}]`,
+    };
+  }
+}
+
 /**
- * Process email body and attachments to markdown using Cloudflare AI toMarkdown
- * Forms an array with all documents (email body + attachments) as blobs,
- * then calls toMarkdown once with the entire array
+ * Process email body and attachments to markdown.
+ * - Image attachments are routed to Claude via Cloudflare AI Gateway, which
+ *   returns a KV-style markdown summary.
+ * - Non-image attachments and the email body go through Cloudflare AI toMarkdown.
  */
 export async function processEmailAndAttachmentsToMarkdown(
   ai: CloudflareAI,
@@ -56,17 +213,24 @@ export async function processEmailAndAttachmentsToMarkdown(
     filename: string;
     contentType: string;
     data: ArrayBuffer;
-  }> = []
+  }> = [],
+  visionConfig?: VisionGatewayConfig
 ): Promise<Array<{ filename: string; content: string }>> {
+  const imageAttachments = visionConfig
+    ? attachments.filter((att) => isImageAttachment(att.contentType))
+    : [];
+  const otherAttachments = visionConfig
+    ? attachments.filter((att) => !isImageAttachment(att.contentType))
+    : attachments;
+
   const markdownDocuments: MarkdownDocument[] = [];
 
   // Add email body if available (prefer HTML over text)
   if (emailHtml || emailText) {
     const content = emailHtml || emailText || '';
     const contentType = emailHtml ? 'text/html' : 'text/plain';
-    
+
     if (content) {
-      // Convert string to ArrayBuffer
       const encoder = new TextEncoder();
       const encoded = encoder.encode(content);
       const contentBuffer = new ArrayBuffer(encoded.length);
@@ -79,49 +243,54 @@ export async function processEmailAndAttachmentsToMarkdown(
     }
   }
 
-  // Add all attachments
-  for (const attachment of attachments) {
+  for (const attachment of otherAttachments) {
     markdownDocuments.push({
       name: attachment.filename,
       blob: new Blob([attachment.data], { type: attachment.contentType }),
     });
   }
 
-  // If no documents to process, return empty array
-  if (markdownDocuments.length === 0) {
-    return [];
-  }
+  const imageResultsPromise = visionConfig
+    ? Promise.all(
+        imageAttachments.map((att) => extractImageToMarkdown(visionConfig, att))
+      )
+    : Promise.resolve<Array<{ filename: string; content: string }>>([]);
 
-  try {
-    // Call toMarkdown once with all documents
-    const results = await ai.toMarkdown(markdownDocuments);
-    const resultArray = Array.isArray(results) ? results : [results];
+  const toMarkdownResultsPromise: Promise<Array<{ filename: string; content: string }>> =
+    markdownDocuments.length === 0
+      ? Promise.resolve([])
+      : (async () => {
+          try {
+            const results = await ai.toMarkdown(markdownDocuments);
+            const resultArray = Array.isArray(results) ? results : [results];
+            return resultArray.map((result) => {
+              if (result.format === 'error') {
+                console.error(
+                  `Error converting ${result.name} to markdown:`,
+                  result.error
+                );
+                return {
+                  filename: result.name,
+                  content: `# ${result.name}\n\n[Conversion error: ${result.error}]`,
+                };
+              }
+              return { filename: result.name, content: result.data || '' };
+            });
+          } catch (error) {
+            console.error('Error converting to markdown:', error);
+            return markdownDocuments.map((doc) => ({
+              filename: doc.name,
+              content: `# ${doc.name}\n\n[AI conversion failed: ${error}]`,
+            }));
+          }
+        })();
 
-    return resultArray.map((result) => {
-      if (result.format === 'error') {
-        console.error(
-          `Error converting ${result.name} to markdown:`,
-          result.error
-        );
-        return {
-          filename: result.name,
-          content: `# ${result.name}\n\n[Conversion error: ${result.error}]`,
-        };
-      }
+  const [imageResults, toMarkdownResults] = await Promise.all([
+    imageResultsPromise,
+    toMarkdownResultsPromise,
+  ]);
 
-      return {
-        filename: result.name,
-        content: result.data || '',
-      };
-    });
-  } catch (error) {
-    console.error('Error converting to markdown:', error);
-    // Fallback: return error messages for all documents
-    return markdownDocuments.map((doc) => ({
-      filename: doc.name,
-      content: `# ${doc.name}\n\n[AI conversion failed: ${error}]`,
-    }));
-  }
+  return [...toMarkdownResults, ...imageResults];
 }
 
 /**

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -52,6 +52,7 @@
 		}
 	],
 	"vars": {
-		"ENVIRONMENT": "production"
+		"ENVIRONMENT": "production",
+		"AI_GATEWAY_ID": "bjrk-invoices"
 	}
 }


### PR DESCRIPTION
## Summary
- Route `image/jpeg|png|gif|webp` attachments to Claude Haiku 4.5 via Cloudflare AI Gateway, bypassing `toMarkdown` (which described images as prose instead of extracting structured fields).
- Claude is prompted to return a KV-style markdown block covering every `InvoiceExtraction` field plus a `document_type` hint, so the downstream Llama extractor sees a clean doc and the `isInvoice` classification stays reliable on non-invoice images.
- Non-image attachments and the email body continue through `toMarkdown`; the two paths run in parallel so total latency is ~max of the two.
- `console.warn` fires when `CLOUDFLARE_ACCOUNT_ID`, `AI_GATEWAY_ID` or `ANTHROPIC_API_KEY` are missing — no silent fallback. `AI_GATEWAY_TOKEN` is optional and sent as `cf-aig-authorization` for authenticated gateways.
- Fixes `manual_test/test_email.py`, which was attaching images as `application/*` (via `MIMEApplication`), defeating the image detection on the worker side.

## Config needed before deploy
- Create an AI Gateway named `bjrk-invoices` (or update `AI_GATEWAY_ID` to match).
- Set `ANTHROPIC_API_KEY` and `CLOUDFLARE_ACCOUNT_ID` as secrets.
- If the gateway is authenticated, also set `AI_GATEWAY_TOKEN` (CF API token with AI Gateway Run).

## Test plan
- [ ] `pnpm exec tsc --noEmit` passes
- [ ] Send `test_invoice_1.jpg` via `manual_test/test_email.py`, confirm the silver-layer markdown is the KV list (not prose), request visible in the AI Gateway dashboard
- [ ] Send `test_invoice_1.pdf`, confirm it still flows through `toMarkdown` unchanged
- [ ] Send an image that isn't an invoice (e.g. a photo), confirm `document_type` is not `invoice` and the email is skipped via the existing `isInvoice` gate
- [ ] Temporarily unset `ANTHROPIC_API_KEY` in `.dev.vars`, confirm the warning line appears in the log stream